### PR TITLE
[FEAT][#61] ordena usuários pelo nome ao buscar todos os usuários

### DIFF
--- a/src/app/dao/UserDao.ts
+++ b/src/app/dao/UserDao.ts
@@ -16,7 +16,11 @@ interface User {
 class UserDao {
 
     async getUsers() {
-        return db.user.findMany();
+        return db.user.findMany({
+            orderBy: {
+                name: 'asc'
+            }
+        });
     }
 
     async getUserById(id: number) {


### PR DESCRIPTION
*Alteração:*
- Modificado o db.user.findMany() em getUsers() para incluir orderBy: { name: 'asc' }, garantindo que os usuários sejam sempre retornados em ordem alfabética pelo nome.

*Motivação:*
- Melhora a usabilidade e a consistência da interface ao apresentar os usuários sempre em uma ordem previsível e lógica.